### PR TITLE
fix(import): copy company from billing to shipping address when empty

### DIFF
--- a/src/Service/LengowImportOrder.php
+++ b/src/Service/LengowImportOrder.php
@@ -1140,6 +1140,10 @@ class LengowImportOrder
                 $this->orderData,
                 $this->packageData->delivery
             );
+            // get company from billing address if empty in shipping address
+            if (empty($shippingAddressApi->company) && !empty($billingAddressApi->company)) {
+                $shippingAddressApi->company = $billingAddressApi->company;
+            }
             $this->lengowAddress->init([
                 'billing_data' => $billingAddressApi,
                 'shipping_data' => $shippingAddressApi,

--- a/src/Service/LengowImportOrder.php
+++ b/src/Service/LengowImportOrder.php
@@ -1140,8 +1140,13 @@ class LengowImportOrder
                 $this->orderData,
                 $this->packageData->delivery
             );
-            // get company from billing address if empty in shipping address
-            if (empty($shippingAddressApi->company) && !empty($billingAddressApi->company)) {
+            // get company from billing address if empty in shipping address (only for B2B orders)
+            if (
+                isset($this->orderTypes[LengowOrder::TYPE_BUSINESS])
+                && $this->orderTypes[LengowOrder::TYPE_BUSINESS]
+                && empty($shippingAddressApi->company)
+                && !empty($billingAddressApi->company)
+            ) {
                 $shippingAddressApi->company = $billingAddressApi->company;
             }
             $this->lengowAddress->init([


### PR DESCRIPTION
When importing Amazon B2B orders, the delivery address can have an empty company field while the billing address contains it. This adds a fallback to copy company from billing to shipping address, matching the fix already applied on plugin-prestashop.

Jira: https://lengow.atlassian.net/browse/PCMT-1797